### PR TITLE
Add exception handling to get_video_length

### DIFF
--- a/edlstrip/__init__.py
+++ b/edlstrip/__init__.py
@@ -1,6 +1,7 @@
 import os, sys, subprocess, logging
 import argparse
 import tempfile
+import re
 from shutil import which
 
 ## 
@@ -90,7 +91,12 @@ def get_video_length(input_video):
     Extracts the duration/length of the video we're splitting
     """
     result = subprocess.run(['ffprobe', '-v', 'error', '-show_entries', 'format=duration', '-of', 'default=noprint_wrappers=1:nokey=1', input_video], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    length = float(result.stdout)
+    try:
+        length = float(result.stdout)
+    except:
+        result.stdout = result.stdout.decode('utf-8')
+        errorMessage = re.search(r"\d+\.\d+",result.stdout)
+        length = float(errorMessage.group())
     logging.debug(f"Length of {input_video}: {length}s")
     return length
 


### PR DESCRIPTION
Fixes Issue #7 by adding some basic exception handling. Since the error message of ```ffprobe``` does still contain the duration and this duration does still appear to be correct despite the error (at least in our two examples), I extract the video length via a regex.